### PR TITLE
Fix CI fixture import

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from pathlib import Path
 
 import pytest
 


### PR DESCRIPTION
## Summary
- restore the missing `Path` import in the pytest fixture setup
- fix the Postgres-backed CI test run on GitHub Actions

## Verification
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/dev2prod_test uv run pytest`
