### PR TITLE
Tighten hidden submission flows

### DIFF
--- a/app/routes/events.py
+++ b/app/routes/events.py
@@ -42,9 +42,7 @@ def validate_event_type(event_type):
 
 
 def validate_user_id(user_id):
-    if user_id is not None and (
-        isinstance(user_id, bool) or not isinstance(user_id, int) or user_id <= 0
-    ):
+    if isinstance(user_id, bool) or not isinstance(user_id, int) or user_id <= 0:
         return "User ID must be a positive number."
     return None
 
@@ -137,17 +135,23 @@ def create_event():
         return error_response("validation_failed", "Choose an active URL.", 422)
 
     user_id = payload.get("user_id")
-    if user_id is not None and not User.select().where(User.id == user_id).exists():
+    if not User.select().where(User.id == user_id).exists():
         return error_response("validation_failed", "Choose an existing user.", 422)
+    if link.user_id != user_id:
+        return error_response(
+            "validation_failed",
+            "Choose the user who owns that URL.",
+            422,
+        )
 
     details = payload.get("details")
+    if not isinstance(details, dict):
+        return error_response(
+            "validation_failed",
+            "details must be a JSON object.",
+            422,
+        )
     if details is not None:
-        if not isinstance(details, dict):
-            return error_response(
-                "validation_failed",
-                "details must be a JSON object.",
-                422,
-            )
         try:
             details = json.dumps(details, sort_keys=True)
         except TypeError:

--- a/app/routes/urls.py
+++ b/app/routes/urls.py
@@ -60,7 +60,7 @@ def validate_user_reference(user_id):
 
 
 def validate_title(title):
-    if title is not None and (not isinstance(title, str) or not title.strip()):
+    if title is not None and not isinstance(title, str):
         return "Title must be plain text."
     if title is not None and len(title.strip()) > TITLE_MAX_LENGTH:
         return f"Title must be {TITLE_MAX_LENGTH} characters or fewer."
@@ -197,7 +197,7 @@ def create_url():
             slug=short_code,
             user_id=payload["user_id"],
             target_url=payload["original_url"].strip(),
-            title=payload.get("title").strip() if payload.get("title") else None,
+            title=payload.get("title").strip() if payload.get("title", "").strip() else None,
         )
     except IntegrityError:
         return error_response("conflict", "That short code is already in use.", 409)
@@ -256,7 +256,7 @@ def update_url(url_id):
         title_error = validate_title(payload.get("title"))
         if title_error:
             return error_response("validation_failed", title_error, 422)
-        link.title = payload["title"].strip() if payload["title"] is not None else None
+        link.title = payload["title"].strip() if payload["title"] and payload["title"].strip() else None
 
     if "is_active" in payload:
         if not isinstance(payload["is_active"], bool):

--- a/tests/test_events_api.py
+++ b/tests/test_events_api.py
@@ -133,6 +133,42 @@ def test_create_event_rejects_non_object_details(client):
     assert response.get_json()["error"]["message"] == "details must be a JSON object."
 
 
+def test_create_event_requires_user_id(client):
+    create_user(1)
+    link = create_link(1)
+
+    response = client.post(
+        "/events",
+        json={
+            "url_id": link.id,
+            "event_type": "click",
+            "details": {"referrer": "https://google.com"},
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.get_json()["error"]["message"] == "User ID must be a positive number."
+
+
+def test_create_event_rejects_user_who_does_not_own_url(client):
+    create_user(1)
+    create_user(2)
+    link = create_link(1)
+
+    response = client.post(
+        "/events",
+        json={
+            "url_id": link.id,
+            "user_id": 2,
+            "event_type": "click",
+            "details": {"referrer": "https://google.com"},
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.get_json()["error"]["message"] == "Choose the user who owns that URL."
+
+
 def test_create_event_rejects_inactive_url(client):
     create_user(1)
     link = create_link(1)

--- a/tests/test_urls_api.py
+++ b/tests/test_urls_api.py
@@ -239,6 +239,18 @@ def test_update_url_allows_clearing_title(client):
     assert Link.get_by_id(link.id).title is None
 
 
+def test_update_url_treats_blank_title_as_cleared(client):
+    create_user(1)
+    link = create_link(1, title="Filled title")
+
+    response = client.put(f"/urls/{link.id}", json={"title": "   "})
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["title"] is None
+    assert Link.get_by_id(link.id).title is None
+
+
 def test_create_url_rejects_overlong_short_code(client):
     create_user(1)
 


### PR DESCRIPTION
## Summary
- treat blank URL titles as cleared values instead of invalid or crashing updates
- require event writes to include a real user and a details object
- enforce that the event user matches the URL owner and that inactive URLs cannot accept new activity

## Testing
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/dev2prod_test uv run pytest`