### PR TITLE
Fix user create sequence drift

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -12,6 +12,25 @@ class BaseModel(Model):
         database = db
 
 
+def quote_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+def sync_primary_key_sequence(model) -> None:
+    table_name = quote_identifier(model._meta.table_name)
+    primary_key = model._meta.primary_key.column_name
+    quoted_primary_key = quote_identifier(primary_key)
+    db.execute_sql(
+        f"""
+        SELECT setval(
+            pg_get_serial_sequence('{table_name}', '{primary_key}'),
+            COALESCE((SELECT MAX({quoted_primary_key}) FROM {table_name}), 1),
+            COALESCE((SELECT MAX({quoted_primary_key}) FROM {table_name}) IS NOT NULL, FALSE)
+        )
+        """
+    )
+
+
 def is_postgres_url(database_url: str) -> bool:
     scheme = urlparse(database_url).scheme.lower()
     return scheme in {"postgres", "postgresql"}

--- a/app/routes/users.py
+++ b/app/routes/users.py
@@ -5,6 +5,7 @@ from flask import Blueprint, jsonify, request
 from peewee import DoesNotExist, IntegrityError
 from peewee import fn
 
+from app.database import sync_primary_key_sequence
 from app.errors import error_response
 from app.models import Event, Link, User
 from app.services import import_users_csv
@@ -66,8 +67,9 @@ def get_user_or_none(user_id):
         return None
 
 
-def reuse_user_for_create(normalized_username, normalized_email):
-    existing_user = get_existing_user_by_email(normalized_email)
+def reuse_user_for_create(normalized_username, normalized_email, existing_user=None):
+    if existing_user is None:
+        existing_user = get_existing_user_by_email(normalized_email)
     if existing_user is None:
         return error_response("conflict", "That email is already in use.", 409)
 
@@ -87,6 +89,22 @@ def reuse_user_for_create(normalized_username, normalized_email):
     existing_user.username = normalized_username
     existing_user.save()
     return jsonify(serialize_user(existing_user)), 201
+
+
+def resolve_create_user_conflict(normalized_username, normalized_email):
+    existing_user = get_existing_user_by_email(normalized_email)
+    if existing_user is not None:
+        return reuse_user_for_create(
+            normalized_username,
+            normalized_email,
+            existing_user=existing_user,
+        )
+
+    username_owner = get_existing_user_by_username(normalized_username)
+    if username_owner is not None:
+        return error_response("conflict", "That username is already in use.", 409)
+
+    return None
 
 
 @users_bp.get("/users")
@@ -159,7 +177,28 @@ def create_user():
             email=normalized_email,
         )
     except IntegrityError:
-        return reuse_user_for_create(normalized_username, normalized_email)
+        conflict_response = resolve_create_user_conflict(
+            normalized_username,
+            normalized_email,
+        )
+        if conflict_response is not None:
+            return conflict_response
+
+        sync_primary_key_sequence(User)
+
+        try:
+            user = User.create(
+                username=normalized_username,
+                email=normalized_email,
+            )
+        except IntegrityError:
+            conflict_response = resolve_create_user_conflict(
+                normalized_username,
+                normalized_email,
+            )
+            if conflict_response is not None:
+                return conflict_response
+            raise
 
     return jsonify(serialize_user(user)), 201
 

--- a/app/services/seeding.py
+++ b/app/services/seeding.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from peewee import IntegrityError
 
-from app.database import db
+from app.database import db, sync_primary_key_sequence
 from app.models import Event, Link, User
 
 CSV_TIMESTAMP = "%Y-%m-%d %H:%M:%S"
@@ -132,6 +132,7 @@ def import_urls_csv(path: str | Path) -> dict:
                     setattr(link, field, value)
                 link.save()
                 updated += 1
+        sync_primary_key_sequence(Link)
     finally:
         if opened_here and not db.is_closed():
             db.close()
@@ -182,6 +183,7 @@ def import_users_csv(path: str | Path) -> dict:
                     updated += 1
                 except IntegrityError as error:
                     raise ValueError("Seed file contains conflicting user data.") from error
+        sync_primary_key_sequence(User)
     finally:
         if opened_here and not db.is_closed():
             db.close()
@@ -227,6 +229,7 @@ def import_events_csv(path: str | Path) -> dict:
                     setattr(event, field, value)
                 event.save()
                 updated += 1
+        sync_primary_key_sequence(Event)
     finally:
         if opened_here and not db.is_closed():
             db.close()

--- a/tests/test_seeding.py
+++ b/tests/test_seeding.py
@@ -121,6 +121,27 @@ def test_import_users_csv_allows_repeated_usernames(app, tmp_path):
     assert User.select().where(User.username == "sharedname").count() == 2
 
 
+def test_import_users_csv_syncs_primary_key_sequence(app, tmp_path):
+    csv_path = tmp_path / "users.csv"
+    write_users_csv(
+        csv_path,
+        [
+            {
+                "id": "4",
+                "username": "seeded-user",
+                "email": "seeded-user@example.com",
+                "created_at": "2024-04-12 11:11:33",
+            }
+        ],
+    )
+
+    import_users_csv(csv_path)
+
+    user = User.create(username="next-user", email="next-user@example.com")
+
+    assert user.id == 5
+
+
 def test_import_urls_csv_creates_links(app, tmp_path):
     csv_path = tmp_path / "urls.csv"
     write_urls_csv(
@@ -317,3 +338,4 @@ def test_import_events_csv_rejects_unknown_links(app, tmp_path):
         assert str(exc) == "Seed event references an unknown url_id: 999"
     else:
         raise AssertionError("Expected import_events_csv to reject unknown links.")
+

--- a/tests/test_users_api.py
+++ b/tests/test_users_api.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime
 from io import BytesIO
 
+from app.database import db
 from app.models import Event, Link, User
 from app.routes import users as users_routes
 from peewee import IntegrityError
@@ -33,6 +34,60 @@ def test_bulk_import_users(client):
     assert response.status_code == 201
     assert response.get_json() == {"count": 2}
     assert User.select().count() == 2
+
+
+def test_create_user_after_bulk_import_uses_next_id(client):
+    csv_payload = "\n".join(
+        [
+            "id,username,email,created_at",
+            "1,silvertrail15,silvertrail15@hackstack.io,2025-09-19 22:25:05",
+            "2,urbancanyon36,urbancanyon36@opswise.net,2024-04-09 02:51:03",
+        ]
+    )
+
+    bulk_response = client.post(
+        "/users/bulk",
+        data={"file": (BytesIO(csv_payload.encode("utf-8")), "users.csv")},
+        content_type="multipart/form-data",
+    )
+
+    assert bulk_response.status_code == 201
+
+    create_response = client.post(
+        "/users",
+        json={"username": "testuser_create", "email": "testuser_create@example.com"},
+    )
+
+    assert create_response.status_code == 201
+    payload = create_response.get_json()
+    assert payload["id"] == 3
+    assert payload["username"] == "testuser_create"
+    assert payload["email"] == "testuser_create@example.com"
+
+
+def test_create_user_recovers_when_id_sequence_is_behind(client):
+    create_user(1, "seed-user-one", "seed-user-one@example.com")
+    create_user(2, "seed-user-two", "seed-user-two@example.com")
+    db.execute_sql(
+        """
+        SELECT setval(
+            pg_get_serial_sequence('\"user\"', 'id'),
+            1,
+            TRUE
+        )
+        """
+    )
+
+    response = client.post(
+        "/users",
+        json={"username": "testuser_create", "email": "testuser_create@example.com"},
+    )
+
+    assert response.status_code == 201
+    payload = response.get_json()
+    assert payload["id"] == 3
+    assert payload["username"] == "testuser_create"
+    assert payload["email"] == "testuser_create@example.com"
 
 
 def test_list_users(client):


### PR DESCRIPTION
## Summary
- fix the `/users` create path when Postgres primary key sequences are behind seeded rows
- resync user ids after CSV imports so the next create uses the correct id
- add regression coverage for bulk-import and out-of-sync sequence cases

## Verification
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/dev2prod_test uv run pytest tests/test_users_api.py tests/test_seeding.py -q --no-cov`