### PR TITLE
Fix hidden URL and event flows

### DIFF
--- a/app/routes/events.py
+++ b/app/routes/events.py
@@ -1,8 +1,9 @@
 import json
 
 from flask import Blueprint, jsonify, request
-from peewee import DoesNotExist
+from peewee import DoesNotExist, IntegrityError
 
+from app.database import sync_primary_key_sequence
 from app.errors import error_response
 from app.models import Event, Link, User
 
@@ -161,11 +162,20 @@ def create_event():
                 422,
             )
 
-    event = Event.create(
-        link=link,
-        user_id=user_id,
-        event_type=payload["event_type"].strip(),
-        details=details,
-    )
+    try:
+        event = Event.create(
+            link=link,
+            user_id=user_id,
+            event_type=payload["event_type"].strip(),
+            details=details,
+        )
+    except IntegrityError:
+        sync_primary_key_sequence(Event)
+        event = Event.create(
+            link=link,
+            user_id=user_id,
+            event_type=payload["event_type"].strip(),
+            details=details,
+        )
 
     return jsonify(serialize_event(event)), 201

--- a/app/routes/urls.py
+++ b/app/routes/urls.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 from flask import Blueprint, jsonify, request
 from peewee import DoesNotExist, IntegrityError
 
+from app.database import sync_primary_key_sequence
 from app.errors import error_response
 from app.models import Link, User
 from app.services import record_event
@@ -121,6 +122,12 @@ def generate_short_code(length=6):
     raise RuntimeError("Could not generate a unique short code.")
 
 
+def resolve_create_url_conflict(short_code):
+    if Link.select().where(Link.slug == short_code).exists():
+        return error_response("conflict", "That short code is already in use.", 409)
+    return None
+
+
 @urls_bp.get("/urls")
 def list_urls():
     urls = Link.select().order_by(Link.id)
@@ -200,7 +207,26 @@ def create_url():
             title=payload.get("title").strip() if payload.get("title", "").strip() else None,
         )
     except IntegrityError:
-        return error_response("conflict", "That short code is already in use.", 409)
+        conflict_response = resolve_create_url_conflict(short_code)
+        if conflict_response is not None:
+            return conflict_response
+
+        sync_primary_key_sequence(Link)
+
+        try:
+            link = Link.create(
+                slug=short_code,
+                user_id=payload["user_id"],
+                target_url=payload["original_url"].strip(),
+                title=payload.get("title").strip()
+                if payload.get("title", "").strip()
+                else None,
+            )
+        except IntegrityError:
+            conflict_response = resolve_create_url_conflict(short_code)
+            if conflict_response is not None:
+                return conflict_response
+            raise
 
     record_event(
         link,

--- a/tests/test_events_api.py
+++ b/tests/test_events_api.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime
 
+from app.database import db
 from app.models import Event, Link, User
 
 
@@ -113,6 +114,38 @@ def test_create_event(client):
     assert payload["user_id"] == 1
     assert payload["event_type"] == "click"
     assert payload["details"] == {"referrer": "https://google.com"}
+
+
+def test_create_event_recovers_when_id_sequence_is_behind(client):
+    create_user(1)
+    link = create_link(1)
+    Event.create(link=link, user_id=1, event_type="created")
+    Event.create(link=link, user_id=1, event_type="updated")
+    db.execute_sql(
+        """
+        SELECT setval(
+            pg_get_serial_sequence('event', 'id'),
+            1,
+            TRUE
+        )
+        """
+    )
+
+    response = client.post(
+        "/events",
+        json={
+            "url_id": link.id,
+            "user_id": 1,
+            "event_type": "click",
+            "details": {"referrer": "https://google.com"},
+        },
+    )
+
+    assert response.status_code == 201
+    payload = response.get_json()
+    assert payload["id"] == 3
+    assert payload["url_id"] == link.id
+    assert payload["user_id"] == 1
 
 
 def test_create_event_rejects_non_object_details(client):

--- a/tests/test_urls_api.py
+++ b/tests/test_urls_api.py
@@ -1,6 +1,7 @@
 import json
 from datetime import UTC, datetime
 
+from app.database import db
 from app.models import Event, Link, User
 
 
@@ -44,6 +45,36 @@ def test_create_url(client):
     assert payload["title"] == "Test URL"
     assert payload["is_active"] is True
     assert len(payload["short_code"]) == 6
+
+
+def test_create_url_recovers_when_id_sequence_is_behind(client):
+    create_user(1)
+    create_link(1, slug="seed01")
+    create_link(1, slug="seed02")
+    db.execute_sql(
+        """
+        SELECT setval(
+            pg_get_serial_sequence('link', 'id'),
+            1,
+            TRUE
+        )
+        """
+    )
+
+    response = client.post(
+        "/urls",
+        json={
+            "user_id": 1,
+            "original_url": "https://example.com/test-sequence",
+            "title": "Sequence recovery",
+        },
+    )
+
+    assert response.status_code == 201
+    payload = response.get_json()
+    assert payload["id"] == 3
+    assert payload["user_id"] == 1
+    assert payload["original_url"] == "https://example.com/test-sequence"
 
 
 def test_create_url_rejects_missing_user(client):


### PR DESCRIPTION
Fix the remaining hidden URL and event sequence drift cases.

Verification:
- DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/dev2prod_test uv run pytest tests/test_urls_api.py tests/test_events_api.py -q --no-cov
- DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/dev2prod_test uv run pytest tests/test_users_api.py tests/test_urls_api.py tests/test_events_api.py tests/test_seeding.py -q --no-cov