### PR TITLE
Surface runtime foundation in docs and Add contributor links to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ flowchart LR
 
 Source: [platform-overview.mmd](docs/assets/diagrams/platform-overview.mmd)
 
+## Runtime Foundation
+
+The live platform is built on a small set of runtime choices that matter to the overall story:
+
+- **DigitalOcean Kubernetes** runs the client, control plane, reference workload, and Redis cache.
+- **DigitalOcean Managed PostgreSQL** is the system-of-record database for the workload.
+- **Redis** is used as a read cache, not as primary storage.
+- **GitHub Actions** acts as both the release gate and the deploy trigger.
+- **The control plane keeps the client live through Server-Sent Events**, pushing normalized cluster and experiment snapshots instead of forcing the UI to poll raw infrastructure state directly.
+
 ## The Story Behind The Platform
 
 Dev2Prod is built around a simple belief: if a deployment only looks healthy when nothing goes wrong, that is not enough.

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -907,6 +907,81 @@ button:disabled {
   color: #1b2840;
 }
 
+.documentation-contributors {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  padding: 1.35rem 1.5rem 1.5rem;
+}
+
+.documentation-contributor-card {
+  display: grid;
+  gap: 0.9rem;
+  padding: 1rem 1.05rem;
+  border: 1px solid rgba(19, 32, 51, 0.08);
+  background: #fcfaf5;
+}
+
+.documentation-contributor-card__header {
+  display: grid;
+}
+
+.documentation-contributor-card__header strong {
+  font-size: 1.08rem;
+  color: #1b2840;
+  letter-spacing: -0.03em;
+}
+
+.documentation-contributor-card__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+}
+
+.documentation-contributor-card__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  min-height: 2.25rem;
+  padding: 0 0.8rem;
+  border: 1px solid rgba(19, 32, 51, 0.1);
+  border-radius: 999px;
+  background: #fffefb;
+  color: var(--muted);
+  transition:
+    transform 180ms ease,
+    border-color 180ms ease,
+    background-color 180ms ease,
+    color 180ms ease;
+}
+
+.documentation-contributor-card__link:hover {
+  transform: translateY(-1px);
+  border-color: rgba(21, 115, 107, 0.24);
+  background: #f8fffd;
+  color: var(--accent);
+}
+
+.documentation-contributor-card__link span:last-child {
+  font-size: 0.92rem;
+  color: inherit;
+}
+
+.documentation-contributor-card__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  color: #1b2840;
+}
+
+.documentation-contributor-card__icon svg {
+  width: 100%;
+  height: 100%;
+  fill: currentColor;
+}
+
 .performance-grid,
 .performance-layout {
   display: grid;
@@ -2124,7 +2199,9 @@ button:disabled {
   .performance-lane-stats,
   .performance-result-grid,
   .documentation-video-grid,
-  .documentation-link-grid {
+  .documentation-link-grid,
+  .documentation-contributors,
+  .documentation-contributor-card__links {
     grid-template-columns: 1fr;
   }
 
@@ -2236,7 +2313,8 @@ button:disabled {
   .workspace-activity-card,
   .performance-section__header,
   .documentation-video-stack,
-  .documentation-groups {
+  .documentation-groups,
+  .documentation-contributors {
     padding-left: 1rem;
     padding-right: 1rem;
   }

--- a/client/src/pages/DocumentationPage.tsx
+++ b/client/src/pages/DocumentationPage.tsx
@@ -89,6 +89,64 @@ const documentationGroups = [
   },
 ]
 
+type ContributorLinkKind = 'linkedin' | 'website' | 'github'
+
+type Contributor = {
+  name: string
+  links: Array<{
+    label: string
+    href: string
+    kind: ContributorLinkKind
+  }>
+}
+
+const contributors: Contributor[] = [
+  {
+    name: 'Sanjay Baskaran',
+    links: [
+      { label: 'LinkedIn', href: 'https://www.linkedin.com/in/sanjayb-28/', kind: 'linkedin' },
+      { label: 'Website', href: 'https://sanjaybaskaran.dev', kind: 'website' },
+      { label: 'GitHub', href: 'https://github.com/sanjayb-28', kind: 'github' },
+    ],
+  },
+  {
+    name: 'Rahul Kanagaraj',
+    links: [
+      {
+        label: 'LinkedIn',
+        href: 'https://www.linkedin.com/in/rahulkanagaraj/',
+        kind: 'linkedin',
+      },
+      { label: 'Website', href: 'https://rahul-kanagaraj.vercel.app/', kind: 'website' },
+      { label: 'GitHub', href: 'https://github.com/rahulkanagaraj786', kind: 'github' },
+    ],
+  },
+]
+
+function SocialIcon({ kind }: { kind: ContributorLinkKind }) {
+  if (kind === 'linkedin') {
+    return (
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M6.94 8.5H3.56V20h3.38V8.5Zm.22-3.56c0-1.08-.82-1.94-1.91-1.94s-1.91.86-1.91 1.94c0 1.07.82 1.94 1.9 1.94h.01c1.1 0 1.91-.87 1.91-1.94ZM20 12.86c0-3.47-1.85-5.08-4.32-5.08-1.99 0-2.88 1.1-3.38 1.88V8.5H8.94c.04.77 0 11.5 0 11.5h3.38v-6.42c0-.34.03-.68.12-.92.27-.68.89-1.38 1.93-1.38 1.36 0 1.9 1.04 1.9 2.57V20H20v-7.14Z" />
+      </svg>
+    )
+  }
+
+  if (kind === 'github') {
+    return (
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M12 2C6.48 2 2 6.6 2 12.26c0 4.52 2.87 8.35 6.84 9.7.5.1.68-.22.68-.49 0-.24-.01-1.04-.02-1.89-2.78.62-3.37-1.21-3.37-1.21-.46-1.2-1.11-1.52-1.11-1.52-.9-.63.07-.62.07-.62 1 .08 1.52 1.04 1.52 1.04.88 1.55 2.31 1.1 2.87.84.09-.66.35-1.1.63-1.35-2.22-.26-4.55-1.14-4.55-5.08 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.72 0 0 .84-.28 2.75 1.05A9.3 9.3 0 0 1 12 6.9c.85 0 1.71.12 2.52.36 1.9-1.33 2.74-1.05 2.74-1.05.56 1.42.21 2.46.1 2.72.64.72 1.03 1.63 1.03 2.75 0 3.95-2.34 4.82-4.57 5.07.36.32.68.95.68 1.92 0 1.38-.01 2.49-.01 2.83 0 .27.18.59.69.49A10.26 10.26 0 0 0 22 12.26C22 6.6 17.52 2 12 2Z" />
+      </svg>
+    )
+  }
+
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M14 3h7v7h-2V6.41l-8.3 8.3-1.4-1.42 8.29-8.29H14V3ZM5 5h6v2H7v10h10v-4h2v6H5V5Z" />
+    </svg>
+  )
+}
+
 function VideoCard({
   title,
   description,
@@ -243,6 +301,46 @@ export default function DocumentationPage() {
                 ))}
               </div>
             </section>
+          ))}
+        </div>
+      </section>
+
+      <section className="documentation-section">
+        <header className="performance-section__header">
+          <div className="section-heading">
+            <p className="eyebrow">People</p>
+            <h2>Contributors</h2>
+            <p>
+              Direct links to the contributors behind Dev2Prod, including their LinkedIn, personal
+              sites, and GitHub profiles.
+            </p>
+          </div>
+        </header>
+
+        <div className="documentation-contributors">
+          {contributors.map((contributor) => (
+            <article key={contributor.name} className="documentation-contributor-card">
+              <div className="documentation-contributor-card__header">
+                <strong>{contributor.name}</strong>
+              </div>
+
+              <div className="documentation-contributor-card__links">
+                {contributor.links.map((link) => (
+                  <a
+                    key={link.label}
+                    className="documentation-contributor-card__link"
+                    href={link.href}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    <span className="documentation-contributor-card__icon">
+                      <SocialIcon kind={link.kind} />
+                    </span>
+                    <span>{link.label}</span>
+                  </a>
+                ))}
+              </div>
+            </article>
           ))}
         </div>
       </section>

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -69,6 +69,17 @@ flowchart LR
 
 Source: [platform-overview.mmd](assets/diagrams/platform-overview.mmd)
 
+## Runtime Foundation
+
+Under the hood, the live platform depends on a few core pieces:
+
+- **DigitalOcean Kubernetes** hosts the client, control plane, reference workload, and cache layer.
+- **DigitalOcean Managed PostgreSQL** stores the workload data and stays outside the pod lifecycle.
+- **Redis** supports the cache-aware scalability lane and remains separate from the system-of-record database.
+- **GitHub Actions** gates releases and drives the delivery workflow into the cluster.
+
+One technical detail that matters to the user experience is how the control plane talks to the client. The client does not read raw cluster state directly. The control plane translates workload, resource, and experiment state into client-ready snapshots and pushes them over **Server-Sent Events**, which is what keeps the Workspace and Performance surfaces feeling live.
+
 ## Current Product Truth
 
 The live product is intentionally scoped.


### PR DESCRIPTION
This pull request introduces a new "Contributors" section to the documentation page, highlighting the people behind Dev2Prod with direct links to their LinkedIn, personal websites, and GitHub profiles. It also adds supporting styles for the contributor cards and updates documentation to clarify the platform's runtime foundation and architecture.

**Documentation Page Enhancements:**

* Added a "Contributors" section to `DocumentationPage.tsx`, displaying contributor cards with names and social/profile links, and implemented the `SocialIcon` component for visual icons. [[1]](diffhunk://#diff-5fbf8d8e1a047f45a7bb3f2c6804bf05cb0a38ad2e3212bf98856e2caad5a637R92-R149) [[2]](diffhunk://#diff-5fbf8d8e1a047f45a7bb3f2c6804bf05cb0a38ad2e3212bf98856e2caad5a637R307-R346)

**Styling Improvements:**

* Introduced new CSS classes in `index.css` for contributor cards, grid layouts, and responsive adjustments to ensure the new section is visually consistent and mobile-friendly. [[1]](diffhunk://#diff-9ba564eb566d9d518337365ff59440cd64b7217d0ddb75f1c2524003735b99adR910-R984) [[2]](diffhunk://#diff-9ba564eb566d9d518337365ff59440cd64b7217d0ddb75f1c2524003735b99adL2127-R2204) [[3]](diffhunk://#diff-9ba564eb566d9d518337365ff59440cd64b7217d0ddb75f1c2524003735b99adL2239-R2317)

**Documentation Updates:**

* Added a "Runtime Foundation" section to both `README.md` and `docs/platform.md`, providing a clear overview of the platform's core infrastructure choices and how the control plane communicates with the client. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R77-R86) [[2]](diffhunk://#diff-012e978a4ccde59fefeb0c0d32088942194b77ff06b4093006eb731c1b4c7506R72-R82)